### PR TITLE
Add announcement for stickers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Emil Emoji
 
-**Emil Emoji** is a Discord bot designed to notify your server about newly added emojis and soundboard sounds. It monitors emoji creation and soundboard sound events, announcing them in a user-specified channel, configurable via an environment variable (or logs an error if the channel is not found).
+**Emil Emoji** is a Discord bot designed to notify your server about newly added emojis, stickers and soundboard sounds. It monitors emoji/sticker creation and soundboard sound events, announcing them in a user-specified channel, configurable via an environment variable (or logs an error if the channel is not found).
 
 ## Features
 
-- **Emoji Notifications:** Sends a message in the user-specified channel whenever a new emoji is created.
+- **Emoji/Sticker Notifications:** Sends a message in the user-specified channel whenever a new emoji/sticker is created.
 - **Soundboard Notifications:** Announces the addition of new soundboard sounds.
 - **Customizable Behavior:** Easily extend functionality for other emoji-related events or customize the announcement channel.
 
@@ -53,11 +53,11 @@ node dist/index.js
 
 ## How It Works
 
-- The bot listens for emoji creation and soundboard sound creation events in Discord servers where it is added.
+- The bot listens for emoji/sticker creation and soundboard sound creation events in Discord servers where it is added.
 
 - Finds the specified channel (via the `ANNOUNCE_CHANNEL` environment variable) or defaults to `#general` if not specified.
 
-- Sends a celebratory message along with the newly added emoji or soundboard sound.
+- Sends a celebratory message along with the newly added emoji/sticker or soundboard sound.
 
 ## Example Output
 

--- a/src/handlers/stickers.ts
+++ b/src/handlers/stickers.ts
@@ -1,13 +1,12 @@
-import { Sticker, Guild } from "discord.js";
+import { Sticker } from "discord.js";
 import { getAnnouncementChannel } from "../util/channelUtil";
 
 /**
  * Handles the event when a new sticker is created in a server.
- * @param guild - The guild where the sticker was created.
  * @param sticker - The sticker that was created.
  */
-export const onCreateSticker = (guild: Guild, sticker: Sticker) => {
-  const announceChannel = getAnnouncementChannel(guild);
+export const onCreateSticker = (sticker: Sticker) => {
+  const announceChannel = getAnnouncementChannel(sticker.guild);
 
   if (announceChannel) {
     announceChannel.send({
@@ -19,23 +18,21 @@ export const onCreateSticker = (guild: Guild, sticker: Sticker) => {
 
 /**
  * Handles the event when a sticker is deleted from a server.
- * @param guild - The guild where the sticker was deleted.
  * @param sticker - The sticker that was deleted.
  */
-export const onDeleteSticker = (guild: Guild, sticker: Sticker) => {
-  const announceChannel = getAnnouncementChannel(guild);
+export const onDeleteSticker = (sticker: Sticker) => {
+  const announceChannel = getAnnouncementChannel(sticker.guild);
 
   // Handle deletion of sticker
 };
 
 /**
  * Handles the event when a sticker is updated in a server.
- * @param guild - The guild where the sticker was updated.
  * @param oldSticker - The sticker before the update.
  * @param newSticker - The updated sticker.
  */
-export const onUpdateSticker = (guild: Guild, oldSticker: Sticker, newSticker: Sticker) => {
-  const announceChannel = getAnnouncementChannel(guild);
+export const onUpdateSticker = (oldSticker: Sticker, newSticker: Sticker) => {
+  const announceChannel = getAnnouncementChannel(newSticker.guild);
 
   // Handle update of sticker
 };

--- a/src/handlers/stickers.ts
+++ b/src/handlers/stickers.ts
@@ -1,0 +1,41 @@
+import { Sticker, Guild } from "discord.js";
+import { getAnnouncementChannel } from "../util/channelUtil";
+
+/**
+ * Handles the event when a new sticker is created in a server.
+ * @param guild - The guild where the sticker was created.
+ * @param sticker - The sticker that was created.
+ */
+export const onCreateSticker = (guild: Guild, sticker: Sticker) => {
+  const announceChannel = getAnnouncementChannel(guild);
+
+  if (announceChannel) {
+    announceChannel.send({
+      content: `🎉 A new sticker has been added to the server! 🎉`,
+      stickers: [sticker.id],
+    });
+  }
+};
+
+/**
+ * Handles the event when a sticker is deleted from a server.
+ * @param guild - The guild where the sticker was deleted.
+ * @param sticker - The sticker that was deleted.
+ */
+export const onDeleteSticker = (guild: Guild, sticker: Sticker) => {
+  const announceChannel = getAnnouncementChannel(guild);
+
+  // Handle deletion of sticker
+};
+
+/**
+ * Handles the event when a sticker is updated in a server.
+ * @param guild - The guild where the sticker was updated.
+ * @param oldSticker - The sticker before the update.
+ * @param newSticker - The updated sticker.
+ */
+export const onUpdateSticker = (guild: Guild, oldSticker: Sticker, newSticker: Sticker) => {
+  const announceChannel = getAnnouncementChannel(guild);
+
+  // Handle update of sticker
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,41 +42,9 @@ client.on(Events.GuildEmojiDelete, onDeleteEmoji);
 client.on(Events.GuildEmojiUpdate, onUpdateEmoji);
 
 // Register sticker event handlers
-client.on(Events.GuildStickerCreate, (sticker) => {
-  if (!sticker.guildId) {
-    console.warn("Sticker does not have a valid guildId.");
-    return;
-  }
-
-  const guild = client.guilds.cache.get(sticker.guildId);
-  if (guild) {
-    onCreateSticker(guild, sticker);
-  }
-});
-
-client.on(Events.GuildStickerDelete, (sticker) => {
-  if (!sticker.guildId) {
-    console.warn("Sticker does not have a valid guildId.");
-    return;
-  }
-
-  const guild = client.guilds.cache.get(sticker.guildId);
-  if (guild) {
-    onDeleteSticker(guild, sticker);
-  }
-});
-
-client.on(Events.GuildStickerUpdate, (oldSticker, newSticker) => {
-  if (!newSticker.guildId) {
-    console.warn("Sticker does not have a valid guildId.");
-    return;
-  }
-
-  const guild = client.guilds.cache.get(newSticker.guildId);
-  if (guild) {
-    onUpdateSticker(guild, oldSticker, newSticker);
-  }
-});
+client.on(Events.GuildStickerCreate, onCreateSticker);
+client.on(Events.GuildStickerDelete, onDeleteSticker);
+client.on(Events.GuildStickerUpdate, onUpdateSticker);
 
 // Register AuditLog event handlers
 client.on(Events.GuildAuditLogEntryCreate, (auditLog) => onAuditLogEntryCreate({ client, auditLog }));

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { ActivityType, Client, Events, GatewayIntentBits } from 'discord.js';
 import * as dotenv from 'dotenv';
 import { onAuditLogEntryCreate } from './handlers/auditLogs';
 import { onCreateEmoji, onDeleteEmoji, onUpdateEmoji } from './handlers/emojis';
+import { onCreateSticker, onDeleteSticker, onUpdateSticker } from './handlers/stickers';
 
 // Load environment variables from .env file
 dotenv.config();
@@ -39,6 +40,43 @@ client.once(Events.ClientReady, () => {
 client.on(Events.GuildEmojiCreate, onCreateEmoji);
 client.on(Events.GuildEmojiDelete, onDeleteEmoji);
 client.on(Events.GuildEmojiUpdate, onUpdateEmoji);
+
+// Register sticker event handlers
+client.on(Events.GuildStickerCreate, (sticker) => {
+  if (!sticker.guildId) {
+    console.warn("Sticker does not have a valid guildId.");
+    return;
+  }
+
+  const guild = client.guilds.cache.get(sticker.guildId);
+  if (guild) {
+    onCreateSticker(guild, sticker);
+  }
+});
+
+client.on(Events.GuildStickerDelete, (sticker) => {
+  if (!sticker.guildId) {
+    console.warn("Sticker does not have a valid guildId.");
+    return;
+  }
+
+  const guild = client.guilds.cache.get(sticker.guildId);
+  if (guild) {
+    onDeleteSticker(guild, sticker);
+  }
+});
+
+client.on(Events.GuildStickerUpdate, (oldSticker, newSticker) => {
+  if (!newSticker.guildId) {
+    console.warn("Sticker does not have a valid guildId.");
+    return;
+  }
+
+  const guild = client.guilds.cache.get(newSticker.guildId);
+  if (guild) {
+    onUpdateSticker(guild, oldSticker, newSticker);
+  }
+});
 
 // Register AuditLog event handlers
 client.on(Events.GuildAuditLogEntryCreate, (auditLog) => onAuditLogEntryCreate({ client, auditLog }));

--- a/src/util/channelUtil.ts
+++ b/src/util/channelUtil.ts
@@ -4,9 +4,14 @@ import { Guild, TextChannel } from "discord.js";
  * Searches for the announcement channel in the guild.
  * Returns the channel if found, otherwise returns null.
  * @param guild - The guild to search for the announcement channel in.
- * @returns 
+ * @returns The TextChannel if found, otherwise null.
  */
-export const getAnnouncementChannel = (guild: Guild) => {
+export const getAnnouncementChannel = (guild: Guild | null): TextChannel | null => {
+  if (!guild) {
+    console.log("Guild is null. Cannot search for announcement channel.");
+    return null;
+  }
+
   const announceChannelName = process.env.ANNOUNCE_CHANNEL || "general";
 
   const channel = guild.channels.cache.find(


### PR DESCRIPTION
@Bl1zzards 
I added the announcement for stickers in this branch. While I tried to follow the concept that you introduced for emojis, unfortunately, there is no module like `GuildEmoji` for stickers. Instead, I had to work with the `Sticker` module.

Unlike `emoji.guild`, which returns the `Guild` object, `sticker.guild` annoyingly returns either a `Guild` object or `null`. Because of this inconsistency, I had to update the `getAnnouncementChannel` function to handle cases where `sticker.guild` is null.

Can you please test this on your end to see if it still works as intended by you? Thanks 🫂 